### PR TITLE
Update Trivy scan CodeQL Action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -230,7 +230,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Update github/codeql-action/upload-sarif from deprecated v2 to v3 in the
security scan workflow. This resolves the Trivy scan result upload
failures caused by the CodeQL Action v1 and v2 deprecation.

CodeQL Action v2 was deprecated on 2025-01-10 and is no longer supported
for uploading SARIF results to GitHub Security tab.

Fixes: Security scan upload failures in GitHub Actions
Closes: Trivy vulnerability scan result upload issues
