### PR TITLE
fix(templates): update deprecated Karpenter label in nodes-instance

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -108,7 +108,7 @@ Credit: https://github.com/ripta/dotfiles/tree/master/zsh-custom/plugins/kube/te
 
 #### Node Management
 - `nodes.tmpl` - Node capacity and allocatable resources
-- `nodes-instance.tmpl` - Node instance metadata (instance-group, instance-type, provisioner)
+- `nodes-instance.tmpl` - Node instance metadata (instance-group, instance-type, nodepool)
 - `cordoned.tmpl` - Show cordoned nodes with timestamp
 - `taints.tmpl` - Display node taints
 

--- a/templates/nodes-instance.tmpl
+++ b/templates/nodes-instance.tmpl
@@ -1,1 +1,1 @@
-FLAGS:-L kops.k8s.io/instance-group -L node.kubernetes.io/instance-type -L karpenter.sh/provisioner-name --sort-by='.metadata.creationTimestamp'
+FLAGS:-L kops.k8s.io/instance-group -L node.kubernetes.io/instance-type -L karpenter.sh/nodepool --sort-by='.metadata.creationTimestamp'


### PR DESCRIPTION
## Summary
- Replace `karpenter.sh/provisioner-name` with `karpenter.sh/nodepool` in the `nodes-instance` template
- The `provisioner-name` label was removed in Karpenter v1 in favour of `nodepool`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated label selector for Karpenter node resources to reflect current naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->