### PR TITLE
feat: add kubectl-secret plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ kubectl.fish is a collection of kubectl plugins and functions written in Fish sh
 - **kubectl-really-all**: List all namespaced resources across all namespaces
 - **kubectl-why-not-deleted**: Debug stuck resource deletions (requires jq)
 - **kubectl-dyff**: Semantic diff of Kubernetes manifests (requires dyff, yq)
+- **kubectl-secret**: List secret keys or decode a specific key value to stdout
 
 ### Helper Functions
 

--- a/CONSISTENCY.md
+++ b/CONSISTENCY.md
@@ -115,6 +115,13 @@ Every function implements:
 - **Dependencies**: Only kubectl required
 - **Wraps**: `kubectl get`
 
+### kubectl-secret
+
+- **Purpose**: Secret key listing and value decoding
+- **Pattern**: `kubectl get secret $name [flags] -o go-template='...'`
+- **Dependencies**: Only kubectl required
+- **Wraps**: `kubectl get secret`
+
 ### k (Smart Wrapper)
 
 - **Purpose**: Plugin dispatch and enhanced kubectl

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A collection of kubectl plugins and functions written in fish shell, designed to
 - **Enhanced event viewing** with `kubectl-list-events` (sorted by timestamp)
 - **Comprehensive resource listing** with `kubectl-really-all` (all namespaced resources)
 - **Deletion analysis** with `kubectl-why-not-deleted` (debug stuck deletions)
+- **Secret inspection** with `kubectl-secret` (list keys and decode values)
 - **16 production-ready templates** imported from the zsh kubectl plugin
 - **Robust error handling** and prerequisite checking
 - **Comprehensive test suite** for reliability
@@ -89,6 +90,7 @@ k get pods .items[0].metadata.name  # Enhanced get with jq
 k gron pods                   # Uses kubectl-gron function
 k list-events                 # Uses kubectl-list-events function
 k really-all                  # Uses kubectl-really-all function
+k secret my-db-creds               # Uses kubectl-secret function
 ```
 
 ### `kubectl-get` - Enhanced kubectl get with templates and jq
@@ -339,6 +341,40 @@ kubectl-why-not-deleted deployment my-app -n production
 kubectl-why-not-deleted Pod/my-pod-name -n production
 kubectl-why-not-deleted pvc my-volume-claim
 kubectl-why-not-deleted namespace my-namespace
+```
+
+### `kubectl-secret` - Secret key listing and value decoding
+
+View keys or decode values from Kubernetes secrets without leaving the terminal.
+
+**Modes:**
+
+```fish
+kubectl-secret <secret> [-n namespace]        # List all keys in secret
+kubectl-secret <secret> <key> [-n namespace]  # Decode key value to stdout
+```
+
+**Examples:**
+
+```fish
+# List all keys in a secret
+kubectl-secret my-db-creds -n production
+
+# Decode a specific key
+kubectl-secret my-db-creds password -n production
+
+# Copy decoded value to clipboard (macOS)
+kubectl-secret my-db-creds password -n production | pbcopy
+
+# Copy decoded value to clipboard (Linux)
+kubectl-secret my-db-creds password -n production | xclip
+```
+
+**Access via `k`:**
+
+```fish
+k secret my-db-creds -n production
+k secret my-db-creds password -n production | pbcopy
 ```
 
 ## 🧪 Testing

--- a/functions/kubectl-secret.fish
+++ b/functions/kubectl-secret.fish
@@ -1,0 +1,114 @@
+#!/usr/bin/env fish
+
+# kubectl-secret - View and decode Kubernetes secrets
+#
+# DESCRIPTION:
+#     View keys or decode values from Kubernetes secrets.
+#     With only a secret name, lists all available keys.
+#     With a secret name and key, prints the base64-decoded value to stdout.
+#
+# USAGE:
+#     kubectl-secret <secret> [-n namespace] [kubectl-flags...]
+#     kubectl-secret <secret> <key> [-n namespace] [kubectl-flags...]
+#
+# EXAMPLES:
+#     kubectl-secret my-db-creds
+#     kubectl-secret my-db-creds -n production
+#     kubectl-secret my-db-creds password -n production
+#     kubectl-secret my-db-creds password -n production | pbcopy
+#
+# DEPENDENCIES:
+#     - kubectl: Kubernetes command-line tool
+#
+# AUTHOR:
+#     kubectl.fish collection
+
+function kubectl-secret -d "View and decode Kubernetes secrets" --wraps 'kubectl get secret'
+    # Handle help option first
+    if contains -- --help $argv; or contains -- -h $argv
+        echo "kubectl-secret - View and decode Kubernetes secrets"
+        echo ""
+        echo "USAGE:"
+        echo "  kubectl-secret <secret> [-n namespace] [kubectl-flags...]"
+        echo "  kubectl-secret <secret> <key> [-n namespace] [kubectl-flags...]"
+        echo ""
+        echo "DESCRIPTION:"
+        echo "  With only a secret name, lists all available keys in the secret."
+        echo "  With a secret name and key, prints the base64-decoded value to stdout."
+        echo "  Pipe the output to pbcopy (macOS) or xclip (Linux) for clipboard use."
+        echo ""
+        echo "EXAMPLES:"
+        echo "  kubectl-secret my-db-creds"
+        echo "  kubectl-secret my-db-creds -n production"
+        echo "  kubectl-secret my-db-creds password -n production"
+        echo "  kubectl-secret my-db-creds password -n production | pbcopy"
+        echo ""
+        echo "DEPENDENCIES:"
+        echo "  - kubectl: Kubernetes command-line tool"
+        return 0
+    end
+
+    # Validate prerequisites
+    if not command -q kubectl
+        echo "Error: kubectl is not installed or not in PATH" >&2
+        echo "Please install kubectl to use this function" >&2
+        return 1
+    end
+
+    # Validate at least one argument provided
+    if test (count $argv) -eq 0
+        echo "Error: No arguments provided" >&2
+        echo "Usage: kubectl-secret <secret> [key] [kubectl-flags...]" >&2
+        echo "Use 'kubectl-secret --help' for more information" >&2
+        return 1
+    end
+
+    # Parse arguments: separate positional args from kubectl flags
+    set -l positional_args
+    set -l kubectl_flags
+    set -l i 1
+    while test $i -le (count $argv)
+        switch $argv[$i]
+            case -n --namespace --context --cluster --kubeconfig
+                if test (math $i + 1) -le (count $argv)
+                    set kubectl_flags $kubectl_flags $argv[$i] $argv[(math $i + 1)]
+                    set i (math $i + 2)
+                else
+                    echo "Error: $argv[$i] requires a value" >&2
+                    return 1
+                end
+            case '-*'
+                set kubectl_flags $kubectl_flags $argv[$i]
+                set i (math $i + 1)
+            case '*'
+                set positional_args $positional_args $argv[$i]
+                set i (math $i + 1)
+        end
+    end
+
+    # Require secret name
+    if test (count $positional_args) -eq 0
+        echo "Error: Secret name is required" >&2
+        echo "Usage: kubectl-secret <secret> [key] [kubectl-flags...]" >&2
+        echo "Use 'kubectl-secret --help' for more information" >&2
+        return 1
+    end
+
+    set -l secret_name $positional_args[1]
+
+    if test (count $positional_args) -gt 2
+        echo "Error: Too many arguments provided" >&2
+        echo "Usage: kubectl-secret <secret> [key] [kubectl-flags...]" >&2
+        echo "Use 'kubectl-secret --help' for more information" >&2
+        return 1
+    end
+
+    if test (count $positional_args) -ge 2
+        # Decode mode: print base64-decoded value for the given key
+        set -l key $positional_args[2]
+        kubectl get secret $secret_name $kubectl_flags -o go-template="{{index .data \"$key\" | base64decode}}{{\"\\n\"}}"
+    else
+        # List mode: print all keys in the secret
+        kubectl get secret $secret_name $kubectl_flags -o go-template='{{range $k, $v := .data}}{{$k}}{{"\n"}}{{end}}'
+    end
+end

--- a/functions/kubectl-secret.fish
+++ b/functions/kubectl-secret.fish
@@ -69,7 +69,7 @@ function kubectl-secret -d "View and decode Kubernetes secrets" --wraps 'kubectl
     set -l i 1
     while test $i -le (count $argv)
         switch $argv[$i]
-            case -n --namespace --context --cluster --kubeconfig
+            case -n --namespace -o --output --context --cluster --kubeconfig
                 if test (math $i + 1) -le (count $argv)
                     set kubectl_flags $kubectl_flags $argv[$i] $argv[(math $i + 1)]
                     set i (math $i + 2)

--- a/functions/kubectl-secret.fish
+++ b/functions/kubectl-secret.fish
@@ -69,7 +69,11 @@ function kubectl-secret -d "View and decode Kubernetes secrets" --wraps 'kubectl
     set -l i 1
     while test $i -le (count $argv)
         switch $argv[$i]
-            case -n --namespace -o --output --context --cluster --kubeconfig
+            case -o --output
+                echo "Error: -o/--output is not supported; output format is managed internally" >&2
+                echo "Use 'kubectl-secret --help' for more information" >&2
+                return 1
+            case -n --namespace --context --cluster --kubeconfig
                 if test (math $i + 1) -le (count $argv)
                     set kubectl_flags $kubectl_flags $argv[$i] $argv[(math $i + 1)]
                     set i (math $i + 2)
@@ -106,6 +110,10 @@ function kubectl-secret -d "View and decode Kubernetes secrets" --wraps 'kubectl
     if test (count $positional_args) -ge 2
         # Decode mode: print base64-decoded value for the given key
         set -l key $positional_args[2]
+        if not string match -qr '^[-._a-zA-Z0-9]+$' -- $key
+            echo "Error: invalid key name '$key'; keys must match [-._a-zA-Z0-9]+" >&2
+            return 1
+        end
         kubectl get secret $secret_name $kubectl_flags -o go-template="{{index .data \"$key\" | base64decode}}{{\"\\n\"}}"
     else
         # List mode: print all keys in the secret

--- a/functions/kubectl-secret.fish
+++ b/functions/kubectl-secret.fish
@@ -24,8 +24,17 @@
 #     kubectl.fish collection
 
 function kubectl-secret -d "View and decode Kubernetes secrets" --wraps 'kubectl get secret'
-    # Handle help option first
-    if contains -- --help $argv; or contains -- -h $argv
+    argparse --ignore-unknown \
+        h/help \
+        o/output= \
+        n/namespace= \
+        context= \
+        cluster= \
+        kubeconfig= \
+        -- $argv
+    or return 1
+
+    if set -q _flag_help
         echo "kubectl-secret - View and decode Kubernetes secrets"
         echo ""
         echo "USAGE:"
@@ -48,57 +57,35 @@ function kubectl-secret -d "View and decode Kubernetes secrets" --wraps 'kubectl
         return 0
     end
 
-    # Validate prerequisites
+    if set -q _flag_output
+        echo "Error: -o/--output is not supported; output format is managed internally" >&2
+        echo "Use 'kubectl-secret --help' for more information" >&2
+        return 1
+    end
+
     if not command -q kubectl
         echo "Error: kubectl is not installed or not in PATH" >&2
         echo "Please install kubectl to use this function" >&2
         return 1
     end
 
-    # Validate at least one argument provided
-    if test (count $argv) -eq 0
+    # $argv now contains only positionals and any undeclared flags (passed with = form)
+    set -l positional_args
+    set -l extra_flags
+    for arg in $argv
+        if string match -q -- '-*' $arg
+            set extra_flags $extra_flags $arg
+        else
+            set positional_args $positional_args $arg
+        end
+    end
+
+    if test (count $positional_args) -eq 0
         echo "Error: No arguments provided" >&2
         echo "Usage: kubectl-secret <secret> [key] [kubectl-flags...]" >&2
         echo "Use 'kubectl-secret --help' for more information" >&2
         return 1
     end
-
-    # Parse arguments: separate positional args from kubectl flags
-    set -l positional_args
-    set -l kubectl_flags
-    set -l i 1
-    while test $i -le (count $argv)
-        switch $argv[$i]
-            case -o --output
-                echo "Error: -o/--output is not supported; output format is managed internally" >&2
-                echo "Use 'kubectl-secret --help' for more information" >&2
-                return 1
-            case -n --namespace --context --cluster --kubeconfig
-                if test (math $i + 1) -le (count $argv)
-                    set kubectl_flags $kubectl_flags $argv[$i] $argv[(math $i + 1)]
-                    set i (math $i + 2)
-                else
-                    echo "Error: $argv[$i] requires a value" >&2
-                    return 1
-                end
-            case '-*'
-                set kubectl_flags $kubectl_flags $argv[$i]
-                set i (math $i + 1)
-            case '*'
-                set positional_args $positional_args $argv[$i]
-                set i (math $i + 1)
-        end
-    end
-
-    # Require secret name
-    if test (count $positional_args) -eq 0
-        echo "Error: Secret name is required" >&2
-        echo "Usage: kubectl-secret <secret> [key] [kubectl-flags...]" >&2
-        echo "Use 'kubectl-secret --help' for more information" >&2
-        return 1
-    end
-
-    set -l secret_name $positional_args[1]
 
     if test (count $positional_args) -gt 2
         echo "Error: Too many arguments provided" >&2
@@ -107,8 +94,15 @@ function kubectl-secret -d "View and decode Kubernetes secrets" --wraps 'kubectl
         return 1
     end
 
+    set -l kubectl_flags $extra_flags
+    set -q _flag_namespace; and set kubectl_flags $kubectl_flags -n $_flag_namespace
+    set -q _flag_context; and set kubectl_flags $kubectl_flags --context $_flag_context
+    set -q _flag_cluster; and set kubectl_flags $kubectl_flags --cluster $_flag_cluster
+    set -q _flag_kubeconfig; and set kubectl_flags $kubectl_flags --kubeconfig $_flag_kubeconfig
+
+    set -l secret_name $positional_args[1]
+
     if test (count $positional_args) -ge 2
-        # Decode mode: print base64-decoded value for the given key
         set -l key $positional_args[2]
         if not string match -qr '^[-._a-zA-Z0-9]+$' -- $key
             echo "Error: invalid key name '$key'; keys must match [-._a-zA-Z0-9]+" >&2
@@ -116,7 +110,6 @@ function kubectl-secret -d "View and decode Kubernetes secrets" --wraps 'kubectl
         end
         kubectl get secret $secret_name $kubectl_flags -o go-template="{{index .data \"$key\" | base64decode}}{{\"\\n\"}}"
     else
-        # List mode: print all keys in the secret
         kubectl get secret $secret_name $kubectl_flags -o go-template='{{range $k, $v := .data}}{{$k}}{{"\n"}}{{end}}'
     end
 end

--- a/tests/test_kubectl_functions.fish
+++ b/tests/test_kubectl_functions.fish
@@ -13,7 +13,7 @@
 #   - Mock utilities for unit tests
 
 # Test configuration
-set -l test_functions kubectl-gron kubectl-list-events kubectl-really-all kubectl-dump kubectl-why-not-deleted kubectl-dyff kubectl-get kt k __kubectl_find_template __kubectl_parse_get_args __kubectl_complete_templates
+set -l test_functions kubectl-gron kubectl-list-events kubectl-really-all kubectl-dump kubectl-why-not-deleted kubectl-dyff kubectl-get kt k __kubectl_find_template __kubectl_parse_get_args __kubectl_complete_templates kubectl-secret
 set -g test_results_passed 0
 set -g test_results_failed 0
 set -g test_results_skipped 0
@@ -95,6 +95,11 @@ function test_help_functionality
     test_assert "kubectl-why-not-deleted help contains USAGE" "kubectl-why-not-deleted --help | grep -q 'USAGE:'" 0
     test_assert "kubectl-dyff help contains USAGE" "kubectl-dyff --help | grep -q 'USAGE:'" 0
     test_assert "k help contains AVAILABLE FUNCTIONS" "k --help | grep -q 'AVAILABLE KUBECTL.FISH FUNCTIONS:'" 0
+    test_assert "kubectl-secret --help" "kubectl-secret --help >/dev/null 2>&1; test \$status -eq 0" 0
+    test_assert "kubectl-secret -h" "kubectl-secret -h >/dev/null 2>&1; test \$status -eq 0" 0
+    test_assert "kubectl-secret help contains USAGE" "kubectl-secret --help | grep -q 'USAGE:'" 0
+    test_assert "kubectl-secret help contains EXAMPLES" "kubectl-secret --help | grep -q 'EXAMPLES:'" 0
+    test_assert "kubectl-secret help contains DEPENDENCIES" "kubectl-secret --help | grep -q 'DEPENDENCIES:'" 0
 end
 
 function test_prerequisite_checking
@@ -111,6 +116,7 @@ function test_prerequisite_checking
     test_assert "kubectl-why-not-deleted without kubectl command" "kubectl-why-not-deleted pod test" 1
     test_assert "kubectl-dyff without kubectl command" "kubectl-dyff test.yaml" 1
     test_assert "k without kubectl command" "k get pods" 1
+    test_assert "kubectl-secret without kubectl command" "kubectl-secret my-secret" 1
 
     # Restore PATH
     set -x PATH $original_path
@@ -247,6 +253,8 @@ function test_argument_validation
     end
 
     test_assert "k suggests --help" "k 2>&1 | grep -q 'k --help'" 0
+    test_assert "kubectl-secret with no arguments" kubectl-secret 1
+    test_assert "kubectl-secret suggests --help" "kubectl-secret 2>&1 | grep -q 'kubectl-secret --help'" 0
 end
 
 function test_consistency
@@ -258,6 +266,7 @@ function test_consistency
     test_assert "kubectl-why-not-deleted error format" "kubectl-why-not-deleted 2>&1 | grep -q '^Error:'" 0
     test_assert "kubectl-dyff error format" "kubectl-dyff 2>&1 | grep -q '^Error:'" 0
     test_assert "k error format" "k 2>&1 | grep -q '^Error:'" 0
+    test_assert "kubectl-secret error format" "kubectl-secret 2>&1 | grep -q '^Error:'" 0
 
     # Test that all functions use consistent --wraps annotation (check function definition)
     test_assert "kubectl-gron has proper wraps" "functions kubectl-gron | grep -q 'kubectl'" 0
@@ -267,6 +276,7 @@ function test_consistency
     test_assert "kubectl-why-not-deleted has proper wraps" "functions kubectl-why-not-deleted | grep -q 'kubectl'" 0
     test_assert "kubectl-dyff has proper wraps" "functions kubectl-dyff | grep -q 'kubectl'" 0
     test_assert "k has proper wraps" "functions k | grep -q 'kubectl'" 0
+    test_assert "kubectl-secret has proper wraps" "functions kubectl-secret | grep -q 'kubectl'" 0
 end
 
 function test_argument_forwarding
@@ -634,6 +644,57 @@ function test_complete_templates
     functions -e test_complete_templates_lists_names test_complete_templates_strips_tmpl test_complete_templates_strips_template test_complete_templates_empty_dir test_complete_templates_nonexistent
 end
 
+function test_kubectl_secret_forwarding
+    echo "=== Testing kubectl-secret Argument Forwarding ==="
+
+    if not command -q kubectl
+        test_skip "kubectl-secret forwarding tests" "kubectl not available"
+        return
+    end
+
+    function test_kubectl_secret_list_mode
+        set -g temp_secret_list_file (mktemp)
+        function kubectl
+            echo "kubectl $argv" >$temp_secret_list_file
+        end
+
+        kubectl-secret my-secret -n test-namespace >/dev/null 2>&1
+        set -l captured (cat $temp_secret_list_file)
+
+        functions -e kubectl
+        rm -f $temp_secret_list_file
+
+        string match -q '*get secret my-secret*' $captured
+        and string match -q '*test-namespace*' $captured
+        and string match -q '*go-template*' $captured
+        and string match -q '*range*' $captured
+    end
+
+    test_assert "kubectl-secret list mode builds correct kubectl command" test_kubectl_secret_list_mode 0
+
+    function test_kubectl_secret_decode_mode
+        set -g temp_secret_decode_file (mktemp)
+        function kubectl
+            echo "kubectl $argv" >$temp_secret_decode_file
+        end
+
+        kubectl-secret my-secret password -n test-namespace >/dev/null 2>&1
+        set -l captured (cat $temp_secret_decode_file)
+
+        functions -e kubectl
+        rm -f $temp_secret_decode_file
+
+        string match -q '*get secret my-secret*' $captured
+        and string match -q '*test-namespace*' $captured
+        and string match -q '*base64decode*' $captured
+        and string match -q '*password*' $captured
+    end
+
+    test_assert "kubectl-secret decode mode builds correct kubectl command" test_kubectl_secret_decode_mode 0
+
+    functions -e test_kubectl_secret_list_mode test_kubectl_secret_decode_mode
+end
+
 function run_all_tests
     echo "🧪 kubectl.fish Function Test Suite"
     echo "=================================="
@@ -645,6 +706,7 @@ function run_all_tests
     test_argument_validation
     test_consistency
     test_argument_forwarding
+    test_kubectl_secret_forwarding
     test_function_registration
     test_integration_basic
     test_linting_standards

--- a/tests/test_kubectl_functions.fish
+++ b/tests/test_kubectl_functions.fish
@@ -255,6 +255,8 @@ function test_argument_validation
     test_assert "k suggests --help" "k 2>&1 | grep -q 'k --help'" 0
     test_assert "kubectl-secret with no arguments" kubectl-secret 1
     test_assert "kubectl-secret suggests --help" "kubectl-secret 2>&1 | grep -q 'kubectl-secret --help'" 0
+    test_assert "kubectl-secret with too many arguments" "kubectl-secret a b c 2>&1; test \$status -eq 1" 0
+    test_assert "kubectl-secret too many args error format" "kubectl-secret a b c 2>&1 | grep -q '^Error:'" 0
 end
 
 function test_consistency


### PR DESCRIPTION
## Summary

- Adds `kubectl-secret` Fish function that lists keys in a Kubernetes secret or decodes a named key value to stdout
- Accessible as `k secret` via the existing `k` wrapper plugin dispatch
- No new dependencies — both modes use kubectl go-templates (`base64decode`)

## Usage

```fish
# List all keys in a secret
k secret my-db-creds -n production

# Decode a specific key to stdout
k secret my-db-creds password -n production

# Pipe to clipboard
k secret my-db-creds password -n production | pbcopy
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secret-inspection command to list keys in a Kubernetes secret or decode and print a specific secret value.

* **Documentation**
  * Updated README and docs with examples, usage, dependency notes, and a dedicated section for the new secret inspection command.

* **Tests**
  * Added tests covering help text, argument validation, missing-kubectl behavior, and both list/decode execution modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->