### PR TITLE
feat(templates): add nodeclaim-drift template for Karpenter

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -130,6 +130,9 @@ Credit: https://github.com/ripta/dotfiles/tree/master/zsh-custom/plugins/kube/te
 - `crds.tmpl` - Custom Resource Definitions with conversion strategy
 - `finalizers.tmpl` - Resources with finalizers blocking deletion
 
+#### Karpenter
+- `nodeclaim-drift.tmpl` - NodeClaim drift status and reason (Drifted condition)
+
 ## Importing Templates from zsh Plugin
 
 The original inspiration for this feature comes from the zsh kubectl plugin, which includes many production-ready templates. See the implementation plan for importing these templates.

--- a/templates/nodeclaim-drift.tmpl
+++ b/templates/nodeclaim-drift.tmpl
@@ -1,0 +1,1 @@
+NAME:.metadata.name,NODE:.status.nodeName,DRIFTED:.status.conditions[?(@.type=="Drifted")].status,REASON:.status.conditions[?(@.type=="Drifted")].reason


### PR DESCRIPTION
## Summary
- Adds `templates/nodeclaim-drift.tmpl` — a custom-columns template showing NAME, NODE, DRIFTED status, and reason for Karpenter `NodeClaim` resources.
- Lists the new template under a new **Karpenter** subsection in `templates/README.md`.

Usage:
```fish
k get nodeclaims ^nodeclaim-drift
```

Surfaces the `Drifted` condition so you can quickly find NodeClaims marked for replacement and the controller's stated reason, without piping kubectl through jq.

## Test plan
- [x] `make test-unit` — template-related tests pass (the one pre-existing failure on `main` is unrelated to this change)
- [ ] `k get nodeclaims ^nodeclaim-drift` against a cluster running Karpenter
- [ ] `k get nodeclaims ^nodeclaim-drift -n <ns>` with namespace flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Karpenter NodeClaim drift template for tracking drift status and node metadata.

* **Documentation**
  * Updated template documentation to include the new NodeClaim drift template.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ssoriche/kubectl.fish/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->