### PR TITLE
feat(kubectl-get): auto-sort nodeclaims by creation timestamp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,7 @@ NAME:.metadata.name,STATUS:.status.phase,AGE:.metadata.creationTimestamp
 - `events`: Automatically add `--sort-by=.lastTimestamp`
 - `nodes`: Automatically add `--sort-by=.metadata.creationTimestamp`
 - `replicasets`: Automatically add `--sort-by=.metadata.creationTimestamp`
+- `nodeclaims`: Automatically add `--sort-by=.metadata.creationTimestamp`
 - Only applied if no existing `--sort-by` flag
 
 #### Integration Flow

--- a/functions/kubectl-get.fish
+++ b/functions/kubectl-get.fish
@@ -6,7 +6,7 @@
 #     Enhanced wrapper around 'kubectl get' that adds support for:
 #     - Custom-columns templates with ^template-name syntax
 #     - jq field extraction with .field syntax
-#     - Smart auto-sorting for events, nodes, and replicasets
+#     - Smart auto-sorting for events, nodes, replicasets, and nodeclaims
 #
 # USAGE:
 #     kubectl-get RESOURCE [NAME] [FLAGS...]
@@ -36,6 +36,7 @@
 #     - events: Automatically sorted by .lastTimestamp
 #     - nodes: Automatically sorted by .metadata.creationTimestamp
 #     - replicasets: Automatically sorted by .metadata.creationTimestamp
+#     - nodeclaims: Automatically sorted by .metadata.creationTimestamp
 #
 # DEPENDENCIES:
 #     - kubectl: Kubernetes command-line tool
@@ -58,7 +59,7 @@ function kubectl-get -d "Enhanced kubectl get with templates and jq support" --w
         echo "  Enhanced wrapper around 'kubectl get' that adds support for:"
         echo "    - Custom-columns templates with ^template-name syntax"
         echo "    - jq field extraction with .field syntax"
-        echo "    - Smart auto-sorting for events, nodes, and replicasets"
+        echo "    - Smart auto-sorting for events, nodes, replicasets, and nodeclaims"
         echo ""
         echo "EXAMPLES:"
         echo "  kubectl-get pods                    # Standard kubectl get"
@@ -83,6 +84,7 @@ function kubectl-get -d "Enhanced kubectl get with templates and jq support" --w
         echo "  - events: Automatically sorted by .lastTimestamp"
         echo "  - nodes: Automatically sorted by .metadata.creationTimestamp"
         echo "  - replicasets: Automatically sorted by .metadata.creationTimestamp"
+        echo "  - nodeclaims: Automatically sorted by .metadata.creationTimestamp"
         echo ""
         echo "DEPENDENCIES:"
         echo "  - kubectl: Kubernetes command-line tool"
@@ -193,6 +195,8 @@ function kubectl-get -d "Enhanced kubectl get with templates and jq support" --w
             case nodes node no
                 set kubectl_args $kubectl_args "--sort-by=.metadata.creationTimestamp"
             case replicasets replicaset rs
+                set kubectl_args $kubectl_args "--sort-by=.metadata.creationTimestamp"
+            case nodeclaims nodeclaim
                 set kubectl_args $kubectl_args "--sort-by=.metadata.creationTimestamp"
         end
     end


### PR DESCRIPTION
## Summary

`kubectl-get nodeclaims` was not being sorted by age, unlike `kubectl-get nodes` and `kubectl-get replicasets`. The smart-sort `switch` in `kubectl-get.fish` simply had no case for `nodeclaims`, so kubectl's default (unsorted) order was used.

This adds a `nodeclaims`/`nodeclaim` case that appends `--sort-by=.metadata.creationTimestamp` (nodeclaims are cluster-scoped Karpenter CRDs), matching the existing `nodes`/`replicasets` behavior.

## Changes

- `functions/kubectl-get.fish` — add `nodeclaims`/`nodeclaim` case to the smart-sort switch; update header comment and `--help` output.
- `CLAUDE.md` — add `nodeclaims` to the documented smart-sorting list.

## Notes

Smart sorting only applies when the request routes through `kubectl-get`, i.e. when enhanced syntax (`^template` or `.field`) is present. A bare `k get nodeclaims` still falls through to real kubectl unsorted — same as `nodes`.

## Testing

- `fish -n functions/kubectl-get.fish` passes.
- No existing tests cover the smart-sort behavior, so none were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `kubectl get` now supports smart sorting for `nodeclaims`, automatically sorting by creation time when no sort option is set.
  * Help and usage text now reflect the expanded smart-sorting behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->