### PR TITLE
feat: render ^templates containing {{ }} as go-templates, add pods-nodepools

### DIFF
--- a/functions/kubectl-get.fish
+++ b/functions/kubectl-get.fish
@@ -24,9 +24,12 @@
 # TEMPLATE SYNTAX:
 #     ^template-name  - Loads template from:
 #                       $KUBECTL_TEMPLATES_DIR or ~/.kube/templates/
-#                       Templates can be either:
+#                       Templates can be any of:
 #                       - Custom-columns format: NAME:.metadata.name,...
 #                       - FLAGS format: FLAGS:-L label1 -L label2 ...
+#                       - Go template: any content containing {{ }}
+#                         (may span multiple lines; can join across
+#                         resource types, e.g. 'get pods,nodes')
 #
 # JQ SYNTAX:
 #     .field          - Extracts JSON field using jq
@@ -72,9 +75,10 @@ function kubectl-get -d "Enhanced kubectl get with templates and jq support" --w
         echo "TEMPLATE SYNTAX:"
         echo "  ^template-name  - Loads template from:"
         echo "                    \$KUBECTL_TEMPLATES_DIR or ~/.kube/templates/"
-        echo "                    Templates can be either:"
+        echo "                    Templates can be any of:"
         echo "                      - Custom-columns: NAME:.metadata.name,..."
         echo "                      - FLAGS format: FLAGS:-L label1 -L label2 ..."
+        echo "                      - Go template: any content containing {{ }}"
         echo ""
         echo "JQ SYNTAX:"
         echo "  .field          - Extracts JSON field using jq"
@@ -151,13 +155,28 @@ function kubectl-get -d "Enhanced kubectl get with templates and jq support" --w
             return 1
         end
 
-        set -l template_content (cat $template_path)
+        # string collect keeps the file as ONE element with newlines intact.
+        # Without it, command substitution splits on newlines and the quoted
+        # expansion below re-joins with spaces, silently flattening multi-line
+        # Go templates onto a single output line.
+        #
+        # -N additionally preserves the trailing newline, which a Go template
+        # may need as the terminator for its last rendered row. The trimmed
+        # form is used for dispatch matching and for the two single-line
+        # formats, where a trailing newline would land inside the last JSONPath
+        # or the last flag value.
+        set -l template_raw (cat $template_path | string collect -N)
+        set -l template_content (cat $template_path | string collect)
 
         # Check if template uses FLAGS: format instead of custom-columns
         if string match -qr '^FLAGS:' -- $template_content
             # Extract flags after "FLAGS:" prefix and add to kubectl args
             set -l flags (string replace 'FLAGS:' '' -- $template_content)
             set kubectl_args $kubectl_args (string split ' ' -- $flags)
+        else if string match -q '*{{*' -- $template_content
+            # Go template: can join across resource types (kubectl get pods,nodes)
+            # in ways custom-columns cannot, since every item carries its own .kind
+            set kubectl_args $kubectl_args "--output=go-template=$template_raw"
         else
             # Traditional custom-columns template
             set kubectl_args $kubectl_args "--output=custom-columns=$template_content"

--- a/templates/README.md
+++ b/templates/README.md
@@ -158,32 +158,42 @@ This directory includes both example templates and production-ready templates im
 Credit: https://github.com/ripta/dotfiles/tree/master/zsh-custom/plugins/kube/templates
 
 #### Node Management
+
 - `nodes.tmpl` - Node capacity and allocatable resources
 - `nodes-instance.tmpl` - Node instance metadata (instance-group, instance-type, nodepool)
 - `cordoned.tmpl` - Show cordoned nodes with timestamp
 - `taints.tmpl` - Display node taints
 
 #### Pod Analysis
+
 - `images.tmpl` - Pod name, status, and container images
 - `qos.tmpl` - Pod Quality of Service class
 - `owners.tmpl` - Pod ownership references
 - `timestamps.tmpl` - Resource creation, deletion, and start times
 
 #### Service Mesh
+
 - `linkerd.tmpl` - Linkerd service mesh injection and proxy status
 
 #### ScaleOps Integration
+
 - `scaleops-pod.tmpl` - ScaleOps admission and policy info
 - `scaleops-pod-wide.tmpl` - Extended ScaleOps pod details
 - `scaleops-hpa.tmpl` - ScaleOps HPA analysis data
 
 #### Resource Management
+
 - `crds.tmpl` - Custom Resource Definitions with conversion strategy
 - `finalizers.tmpl` - Resources with finalizers blocking deletion
 
 #### Karpenter
+
 - `nodeclaim-drift.tmpl` - NodeClaim drift status and reason (Drifted condition)
 - `pods-nodepools.tmpl` - Pods joined to their node's NodePool (Go template; requires `get pods,nodes`)
+
+#### ArgoCD
+
+- `argocd-status.tmpl` - Application sync status, health, deployed revision, and destination namespace
 
 ## Importing Templates from zsh Plugin
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -34,7 +34,15 @@ set -gx KUBECTL_TEMPLATES_DIR ~/my-custom-templates
 
 ## Template Format
 
-Templates use kubectl's custom-columns format. Each template file contains a single line with the column specification:
+A template file is one of three formats, detected by its content:
+
+| Format | Detected by | Becomes |
+|--------|-------------|---------|
+| custom-columns | anything else (the default) | `--output=custom-columns=…` |
+| flags | leading `FLAGS:` | the listed flags, appended to the command |
+| Go template | contains `{{` | `--output=go-template=…` |
+
+Most templates use kubectl's custom-columns format — a single line of column specifications:
 
 ```
 COLUMN_NAME:JSON_PATH,COLUMN_NAME:JSON_PATH,...
@@ -52,11 +60,52 @@ Usage:
 k get pods ^pods-wide
 ```
 
+### Go Templates
+
+Custom-columns renders one resource type at a time, so it cannot show a value
+that lives on a *different* object. Go templates can, because a multi-resource
+request returns a single `List` in which every item carries its own `.kind`:
+
+```fish
+k get pods,nodes ^pods-nodepools -n my-namespace
+```
+
+Go templates may span multiple lines. `kubectl-get` reads them with `string
+collect` so the newlines survive — without it, fish splits the file on newlines
+and then re-joins with spaces, flattening every rendered row onto one line.
+
+kubectl's template engine is Go's `text/template` plus two extra functions,
+`exists` and `base64decode`. Notably absent:
+
+- **No arithmetic.** There is no `add`, so values cannot be summed (you can list
+  each container's `restartCount`, but not total them).
+- **No `dict`.** Sprig is not available, so a lookup map cannot be built; joins
+  are a nested `range` — a linear scan per item.
+- **No `sort`.**
+
+Guard every field access that may be absent with `exists`, and prefer `printf`
+for column alignment so the output needs no `column -t`.
+
 ## Creating Your Own Templates
 
 1. Create a new `.tmpl` or `.template` file in one of the template directories
-2. Add your custom-columns specification
+2. Write its body in whichever of the three formats fits (see below)
 3. Use it with `k get RESOURCE ^your-template-name`
+
+Which format to reach for:
+
+- **One resource type, one value per column** → custom-columns. Put the column
+  specification on a single line. This is the right default.
+- **Only adding label or field columns** → `FLAGS:` followed by the flags, e.g.
+  `FLAGS:-L app -L tier`.
+- **A value that lives on a different object, or any conditional or fallback
+  logic** → a Go template. Remember that the request must ask for every resource
+  type involved (`k get pods,nodes ^your-template`), or the items you are
+  ranging over will not be there to find.
+
+The dispatcher picks the format from the file's content, not its name — anything
+containing `{{` is treated as a Go template, so a custom-columns file must not
+contain that sequence.
 
 ### Tips for Creating Templates
 
@@ -65,6 +114,8 @@ k get pods ^pods-wide
 - **Arrays**: Use `[*]` for all elements or `[0]` for first element
 - **Nested paths**: Chain with dots (e.g., `.status.conditions[*].type`)
 - **Test with kubectl**: Verify with `kubectl get ... -o json` first
+- **Go templates**: Guard optional fields with `exists`, align with `printf`, and
+  see `pods-nodepools.tmpl` for a worked cross-resource example
 
 ### Example: Creating a Custom Node Template
 
@@ -132,6 +183,7 @@ Credit: https://github.com/ripta/dotfiles/tree/master/zsh-custom/plugins/kube/te
 
 #### Karpenter
 - `nodeclaim-drift.tmpl` - NodeClaim drift status and reason (Drifted condition)
+- `pods-nodepools.tmpl` - Pods joined to their node's NodePool (Go template; requires `get pods,nodes`)
 
 ## Importing Templates from zsh Plugin
 

--- a/templates/pods-nodepools.tmpl
+++ b/templates/pods-nodepools.tmpl
@@ -1,0 +1,28 @@
+{{- /* Pods joined to the Karpenter NodePool (or kops instance-group) of their node.
+
+Requires both resource types in one request, since the nodepool is a label on
+the Node and a Pod only carries .spec.nodeName:
+
+    k get pods,nodes ^pods-nodepools -n my-namespace
+
+Every item in a multi-resource List carries its own .kind (the API server omits
+it on typed lists, but kubectl backfills it on decode), which is what makes the
+nested-range join below possible. There is no dict/map builtin in kubectl's
+template engine, so the inner range is a linear scan per pod.
+
+NODEPOOL prefers karpenter.sh/nodepool and falls back to
+kops.k8s.io/instance-group. Karpenter nodes carry both, and the nodepool is not
+always derivable from the instance-group name, so the real label must win. */ -}}
+{{- $all := .items -}}
+{{- printf "%-46s %-10s %-21s %-33s %s" "POD" "STATUS" "NODE" "NODEPOOL" "INSTANCE-TYPE" }}
+{{ range $p := $all }}{{ if eq $p.kind "Pod" -}}
+{{- $node := "<unscheduled>" }}{{ if exists $p.spec "nodeName" }}{{ $node = $p.spec.nodeName }}{{ end -}}
+{{- $found := false }}{{ $np := "-" }}{{ $type := "-" -}}
+{{- range $n := $all }}{{ if and (eq $n.kind "Node") (eq $n.metadata.name $node) -}}
+{{- $found = true -}}
+{{- if exists $n.metadata.labels "karpenter.sh/nodepool" }}{{ $np = index $n.metadata.labels "karpenter.sh/nodepool" }}{{ else if exists $n.metadata.labels "kops.k8s.io/instance-group" }}{{ $np = index $n.metadata.labels "kops.k8s.io/instance-group" }}{{ end -}}
+{{- if exists $n.metadata.labels "node.kubernetes.io/instance-type" }}{{ $type = index $n.metadata.labels "node.kubernetes.io/instance-type" }}{{ end -}}
+{{- end }}{{ end -}}
+{{- if and (not $found) (ne $node "<unscheduled>") }}{{ $np = "<node-gone>" }}{{ end -}}
+{{- printf "%-46s %-10s %-21s %-33s %s" $p.metadata.name $p.status.phase $node $np $type }}
+{{ end }}{{ end -}}

--- a/tests/test_kubectl_functions.fish
+++ b/tests/test_kubectl_functions.fish
@@ -50,6 +50,66 @@ function test_skip -a description reason
     echo
 end
 
+# Invoke kubectl-get with ^TEMPLATE against a kubectl shim on PATH, then assert
+# something about the argument list the shim actually received. Requires
+# $KUBECTL_CAPTURE and $KUBECTL_TEMPLATES_DIR to be set by the caller.
+#
+# Inspection happens entirely inside this function: a captured argument may
+# contain newlines, and returning one through command substitution would split
+# it, which is the very failure these tests exist to catch.
+#
+#   has-prefix  PREFIX        an argument starts with PREFIX
+#   has-exact   LITERAL       an argument equals LITERAL exactly
+#   equals-value PREFIX VALUE the PREFIX argument, prefix stripped, equals VALUE
+#   equals-file PREFIX FILE   ...equals the exact bytes of FILE
+#   count-lines PREFIX        echo that argument's newline-split element count
+function __test_dispatch -a template_name mode selector expected
+    rm -f $KUBECTL_CAPTURE
+    kubectl-get pods ^$template_name >/dev/null 2>&1
+
+    if not test -f $KUBECTL_CAPTURE
+        return 1
+    end
+
+    set -l args (cat $KUBECTL_CAPTURE | string split0)
+
+    if test $mode = has-exact
+        contains -- $selector $args
+        return $status
+    end
+
+    # The captured argument is compared as-is. Stripping the prefix would mean
+    # piping it through another command, and every command appends a newline of
+    # its own that 'string collect -N' then faithfully preserves -- producing a
+    # spurious second trailing newline and a false failure.
+    for arg in $args
+        if not string match -q -- "$selector*" $arg
+            continue
+        end
+
+        switch $mode
+            case has-prefix
+                return 0
+            case equals-value
+                test "$arg" = "$selector$expected"
+                return $status
+            case equals-file
+                set -l want (cat $expected | string collect -N)
+                test "$arg" = "$selector$want"
+                return $status
+            case count-lines
+                count (string split \n -- $arg)
+                return 0
+        end
+    end
+
+    # count-lines must still emit a number when nothing matched
+    if test $mode = count-lines
+        echo 0
+    end
+    return 1
+end
+
 function check_prerequisites
     echo "=== Checking Prerequisites ==="
 
@@ -507,8 +567,66 @@ function test_kubectl_get_functionality
         test_assert "__kubectl_find_template with KUBECTL_TEMPLATES_DIR" \
             "KUBECTL_TEMPLATES_DIR=$temp_dir __kubectl_find_template test | grep -q 'test.tmpl'" 0
 
+        # Documents the hazard the implementation guards against: plain command
+        # substitution splits a multi-line template into one element per line,
+        # and the quoted expansion in kubectl-get then re-joins with spaces,
+        # flattening every rendered row onto one output line.
+        printf '%s\n%s\n%s\n' '{{ range .items }}' '{{ .metadata.name }}' '{{ end }}' >$temp_dir/multiline.tmpl
+
+        test_assert "plain substitution splits a multi-line template" \
+            "test (count (cat $temp_dir/multiline.tmpl)) -eq 3" 0
+
         # Cleanup
         rm -rf $temp_dir
+    end
+
+    # Verify the arguments kubectl-get actually builds, by invoking it against a
+    # kubectl shim on PATH. Asserting on 'string collect' or 'string match' in
+    # isolation would still pass if the dispatcher stopped emitting
+    # --output=go-template entirely, or flattened the template on the way there.
+    if functions -q kubectl-get
+        set -l shim_dir (mktemp -d)
+        set -l tpl_dir (mktemp -d)
+
+        printf '%s\n' \
+            '#!/bin/sh' \
+            ': >"$KUBECTL_CAPTURE"' \
+            'for a in "$@"; do printf "%s\0" "$a" >>"$KUBECTL_CAPTURE"; done' >$shim_dir/kubectl
+        chmod +x $shim_dir/kubectl
+
+        printf '%s\n%s\n%s\n' '{{ range .items }}' '{{ .metadata.name }}' '{{ end }}' >$tpl_dir/gotmpl.tmpl
+        echo 'NAME:.metadata.name' >$tpl_dir/cc.tmpl
+        echo 'FLAGS:-L app -L tier' >$tpl_dir/flags.tmpl
+
+        set -lx PATH $shim_dir $PATH
+        set -lx KUBECTL_TEMPLATES_DIR $tpl_dir
+        set -lx KUBECTL_CAPTURE $shim_dir/args
+
+        test_assert "go template dispatches to --output=go-template" \
+            "__test_dispatch gotmpl has-prefix '--output=go-template='" 0
+
+        test_assert "dispatched go template matches the file byte for byte" \
+            "__test_dispatch gotmpl equals-file '--output=go-template=' $tpl_dir/gotmpl.tmpl" 0
+
+        test_assert "dispatched go template keeps its newlines" \
+            "test (__test_dispatch gotmpl count-lines '--output=go-template=') -eq 4" 0
+
+        test_assert "custom-columns dispatches its exact spec" \
+            "__test_dispatch cc equals-value '--output=custom-columns=' NAME:.metadata.name" 0
+
+        test_assert "custom-columns is not dispatched as a go template" \
+            "not __test_dispatch cc has-prefix '--output=go-template='" 0
+
+        test_assert "FLAGS template dispatches -L as its own argument" \
+            "__test_dispatch flags has-exact -L" 0
+
+        test_assert "FLAGS template dispatches the label as its own argument" \
+            "__test_dispatch flags has-exact app" 0
+
+        test_assert "FLAGS template sets no output mode" \
+            "not __test_dispatch flags has-prefix --output=" 0
+
+        rm -rf $shim_dir $tpl_dir
     end
 
     # Test argument parsing helper


### PR DESCRIPTION
`kubectl get pods` can show you `.spec.nodeName`, but not the Karpenter NodePool that node belongs to — the nodepool is a label on the Node, and custom-columns renders one resource type per request. So `^pods-wide` stops at the node name and you're left cross-referencing by hand.

Go templates can express the join. A multi-resource request returns a single `List` in which every item carries its own `.kind` — the API server omits it on typed lists, but kubectl backfills it on decode (`apimachinery` `unstructured/helpers.go`, *"For typed lists, e.g., a PodList, API server doesn't set each item's APIVersion and Kind. We need to set it"*). That makes `{{ if eq $p.kind "Pod" }}` a valid filter, and a nested `range` over a captured `$all := .items` does the lookup.

Templates are now dispatched three ways, detected by content: leading `FLAGS:` as before, anything containing `{{` as `--output=go-template=`, everything else as custom-columns. Existing templates are untouched.

### The newline trap

Go templates span multiple lines, and `set -l template_content (cat $template_path)` splits the file into one element per line. The quoted expansion then re-joins with **spaces**, so every rendered row lands on one output line:

```
POD  STATUS  ... INSTANCE-TYPE dbt-run-abc  Running  ... dbt-run-def  Running  ...
```

`string collect` fixes it. Single-line templates are unaffected — collect trims the same trailing newline command substitution already did. Three tests cover this, including one asserting the splitting behaviour being guarded against, so it can't quietly come back.

### pods-nodepools

```fish
k get pods,nodes ^pods-nodepools -n data--dbt--main
```

```
POD                                            STATUS     NODE                  NODEPOOL                          INSTANCE-TYPE
data--dbt--main-3220113m                       Running    i-0c534d0fc82c92c95   spark-spot                        m8gd.4xlarge
data--dbt--main-cm4g105p                       Failed     i-0deadbeef00000001   <node-gone>                       -
data--dbt--main-cnfhp6le                       Running    i-09b0827212dd5463f   scaleops-arm64-on-demand-mirror   m7g.4xlarge
dbt-main-dim-question-e073b89fd92f87cc-exec-1  Running    i-08195d09827e391f0   nginz                             m5d.2xlarge
dbt-main-dim-question-e073b89fd92f87cc-exec-2  Pending    <unscheduled>         -                                 -
```

Three details driven by what real clusters actually look like:

- **NODEPOOL prefers `karpenter.sh/nodepool`, falls back to `kops.k8s.io/instance-group`.** Karpenter nodes carry both, and the nodepool is not derivable from the instance-group name — a node in `ec2nodeclass-arm64-on-demand` can sit in the `scaleops-arm64-on-demand-mirror` nodepool. The fallback keeps genuinely kops-managed nodes (`nginz`, `generic-a`, the masters) from reading as `-`.
- **`<node-gone>` is distinct from `<unscheduled>`.** Evicted pods retain `.spec.nodeName` long after the node was reclaimed, and on a busy namespace that's most of the rows.
- **No CAPACITY or RESTARTS column.** Nodepool names already encode `-spot`/`-on-demand`, and kops nodes have no `karpenter.sh/capacity-type` at all. Restarts can't be summed — kubectl's template engine has no arithmetic.

The README now documents all three template formats and the engine's limits (no arithmetic, no `dict` since sprig isn't available, no `sort`), because those constrain what anyone writes next.

### Verification

Rendering was verified against a harness replicating kubectl's `GoTemplatePrinter` — same `FuncMap` (`exists`, `base64decode`), same `missingkey=default` that `--allow-missing-template-keys` sets, `exists`/`indirect` copied verbatim from `cli-runtime`. Covered: node with no `labels` key, pod whose node no longer exists, unscheduled pod, kops node with no nodepool label, and a nodepool that disagrees with its instance-group. `make lint` clean, 123 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiline Kubernetes Go templates, including templates containing `{{ }}` expressions.
  * Added automatic detection for Go-template, custom-columns, and `FLAGS:` formats.
  * Added a `pods-nodepools` template showing Pod status, node, node pool, and instance type.
  * Displays clear placeholders for unscheduled Pods and missing Nodes.
* **Documentation**
  * Documented supported formats, multiline usage, available functions, limitations, and field guards.
  * Added the new template to the available-template list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->