### PR TITLE
ci: bump actions/checkout to v7 across all workflows

### DIFF
--- a/.forgejo/workflows/test.yaml
+++ b/.forgejo/workflows/test.yaml
@@ -1,5 +1,10 @@
 name: Test kubectl.fish Functions
 
+# actions/checkout is pinned to the same major here as in the GitHub workflows.
+# Keep them in step: Forgejo resolves actions from its own mirror, which forks
+# checkout on a separate lineage, so not every upstream major exists there. As
+# of v7 both lineages have the tag; v5 and v6 exist only upstream.
+
 on:
   push:
     branches: [main, develop]
@@ -12,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell
         run: |
@@ -35,7 +40,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell and dependencies
         run: |
@@ -75,7 +80,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell and dependencies
         run: |
@@ -125,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell
         run: |
@@ -166,7 +171,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell and basic dependencies
         run: |
@@ -209,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check for secrets in code
         run: |
@@ -240,7 +245,7 @@ jobs:
       ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell
         run: |

--- a/.github/workflows/badge.yaml
+++ b/.github/workflows/badge.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Generate badge
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell
         run: |
@@ -71,7 +71,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell
         run: |
@@ -113,7 +113,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell
         run: |
@@ -158,7 +158,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -210,7 +210,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -231,7 +231,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell
         run: |
@@ -283,7 +283,7 @@ jobs:
     needs: [test-unit, test-integration, test-cross-platform, security-scan, documentation]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Fish shell
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ the template formats bumps the minor version until `1.0.0`.
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `actions/checkout` from `@v4` to `@v7` across all 16 usages, in both
+  the GitHub and Forgejo workflows. This clears the Node 20 deprecation warning
+  every run was annotating with — `v4` is `using: node20`, `v5` onward is
+  `node24`.
+- `v7` rather than `v5` specifically so both workflow sets can share a version.
+  Forgejo resolves actions from its own mirror, which forks checkout on a
+  separate lineage; `v5` and `v6` exist only upstream, while `v7` exists in both.
+  Pinning `v5` would have meant leaving Forgejo on `node20` indefinitely with a
+  permanent, unexplainable version skew between the two files.
+
 ## [0.2.0] - 2026-08-11
 
 ### Added


### PR DESCRIPTION
Every workflow run has been annotating:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4

All 16 usages bumped, in both the GitHub and Forgejo workflows.

### v7 rather than v5 — and not because it's newer

For the GitHub workflows the two are equivalent. v5, v6 and v7 are all `using: node24`, and all three carry the same `unsafe-pr-checkout` guard: the `pull_request_target`/`workflow_run` restriction from v7.0.0 was backported to v5.1.0 and v6.1.0, along with its later hardening. I diffed the helper source across the three majors — identical, down to the BOM/NBSP ref-trimming comment. v7's remaining difference is ESM internals.

**The deciding factor is that v7 is the only major both action lineages have.** Forgejo resolves actions from its own mirror, which forks checkout separately:

```
$ curl -s https://code.forgejo.org/api/v1/repos/actions/checkout/tags | jq -r '.[].name'
v7  v7.0.1  v3  v3.7.0  v2  v2.8.0  v4.4.0  v4
```

No `v5`, no `v6`. Pinning v5 would have meant bumping only the nine GitHub usages, leaving the seven Forgejo ones on `node20` indefinitely behind a version skew that needed a paragraph of inline justification to stop someone "fixing" it. Forgejo's `v7` is `node24` and carries the same `unsafe-pr-checkout-helper`, so it genuinely tracks upstream. On v7 both files agree and the inline note reduces to "keep them in step."

### The one workflow using a restricted trigger

`badge.yaml` fires on `workflow_run`, which is exactly what the v7 guard restricts. It's safe: its checkout passes no `ref`, so it takes the default branch rather than fork PR code, and the guard only refuses the latter.

Worth knowing that **`badge.yaml` is not exercised by pull request CI** — it triggers on push to `main` and on `workflow_run` completion, so this PR's green checks don't cover it. It's first validated after merge.

### No release

Recorded under `## [Unreleased]`; `VERSION` stays at `0.2.0`. Verified that leaves the release machinery inert: `make version-check` still passes (Unreleased isn't a version heading, so the newest remains `[0.2.0]`) and `make release-notes` still extracts 0.2.0's section. Nothing can publish by accident.