### PR TITLE
ci: bump remaining Node 20 actions so no workflow is annotated

### DIFF
--- a/.forgejo/workflows/test.yaml
+++ b/.forgejo/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Fish shell
         run: |
@@ -40,7 +40,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Fish shell and dependencies
         run: |
@@ -80,7 +80,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Fish shell and dependencies
         run: |
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Fish shell
         run: |
@@ -171,7 +171,7 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Fish shell and basic dependencies
         run: |
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Check for secrets in code
         run: |
@@ -245,7 +245,7 @@ jobs:
       ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Install Fish shell
         run: |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  # Action references are pinned to commit SHAs, which never move on their own —
+  # a pin with nothing bumping it means never receiving that action's own
+  # security fixes. Dependabot updates the SHA and rewrites the trailing
+  # "# vX.Y.Z" comment to match, so the pin stays both immutable and current.
+  #
+  # Scope note: this only covers .github/workflows. Dependabot does not read
+  # .forgejo/workflows, so the checkout pins there need a manual bump. They are
+  # all the same action at the same SHA, so one edit covers all seven.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/badge.yaml
+++ b/.github/workflows/badge.yaml
@@ -3,10 +3,18 @@ name: Generate CI Badges
 on:
   push:
     branches: [ main ]
+  # zizmor: ignore[dangerous-triggers]
+  # workflow_run runs with the base repository's token and secrets, which is
+  # dangerous only when combined with checking out the triggering pull request's
+  # code. The checkout below passes no ref, so it takes the default branch and
+  # never executes fork-contributed code, and the job holds only contents: read.
   workflow_run:
     workflows: ["Test kubectl.fish Functions"]
     types:
       - completed
+
+permissions:
+  contents: read
 
 jobs:
   badge:
@@ -14,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Generate badge
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          # The release is published with GH_TOKEN via the gh CLI, not by
+          # pushing over git, so the checkout has no need to leave a credential
+          # behind in .git/config.
+          persist-credentials: false
 
       - name: Install Fish shell
         run: |
@@ -28,8 +32,13 @@ jobs:
 
       # The tag is the trigger, so this is the last chance to catch a tag that
       # disagrees with VERSION, or a VERSION with no matching CHANGELOG entry.
+      #
+      # $GITHUB_REF_NAME rather than a ${{ }} interpolation: interpolated values
+      # are substituted into the script before the shell sees them, so a ref
+      # containing shell metacharacters would execute. The env var is passed to
+      # the shell as data.
       - name: Verify tag matches VERSION and CHANGELOG
-        run: make version-check-tag TAG=${{ github.ref_name }}
+        run: make version-check-tag "TAG=$GITHUB_REF_NAME"
 
       - name: Run full test suite
         run: make release-check
@@ -49,7 +58,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
             --notes-file release-notes.md \
             --verify-tag

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,18 +6,31 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+# Least privilege by default. The only job needing more is security-scan, which
+# overrides this to upload its SARIF results.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint and Format Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Fish shell
         run: |
           sudo apt-get update
           sudo apt-get install -y fish
+
+      # Enforces the SHA-pinning policy in CI rather than only in code review,
+      # along with zizmor's other workflow audits. Runs the same make target
+      # contributors run locally.
+      - name: Audit workflows with zizmor
+        run: make audit-workflows
 
       - name: Install fishcheck (optional linter)
         run: |
@@ -71,7 +84,9 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Fish shell
         run: |
@@ -113,7 +128,9 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Fish shell
         run: |
@@ -121,7 +138,7 @@ jobs:
           sudo apt-get install -y fish
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v5
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5
         with:
           version: 'v1.28.0'
 
@@ -133,7 +150,7 @@ jobs:
           sudo mv gron /usr/local/bin/
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           cluster_name: kubectl-fish-test
           wait: 300s
@@ -158,7 +175,9 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Fish shell (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -210,10 +229,12 @@ jobs:
       actions: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -221,7 +242,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
@@ -231,7 +252,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Fish shell
         run: |
@@ -267,7 +290,7 @@ jobs:
           make docs
 
       - name: Check for broken links in README
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1
         with:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'
@@ -283,7 +306,9 @@ jobs:
     needs: [test-unit, test-integration, test-cross-platform, security-scan, documentation]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Fish shell
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,7 +121,7 @@ jobs:
           sudo apt-get install -y fish
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@v5
         with:
           version: 'v1.28.0'
 
@@ -133,7 +133,7 @@ jobs:
           sudo mv gron /usr/local/bin/
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.8.0
+        uses: helm/kind-action@v1
         with:
           cluster_name: kubectl-fish-test
           wait: 300s
@@ -221,7 +221,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,30 @@ the template formats bumps the minor version until `1.0.0`.
   CodeQL Action v3 additionally carried its own deprecation, scheduled for
   December 2026. `setup-kubectl@v4` is still `node20`, so `v5` is the first major
   that resolves it.
-- `helm/kind-action` now tracks the `v1` major rather than an exact patch,
-  matching every other action pin in the file. The exact pin is how it drifted
-  six minor versions behind.
+### Security
+
+- **All 21 action references are pinned to immutable commit SHAs**, with the
+  version kept in a trailing comment. A mutable tag can be repointed by the
+  action owner, or by whoever compromises that account, with nothing appearing in
+  a diff. This includes `aquasecurity/trivy-action`, which tracked the `master`
+  branch — the scanner could change between runs.
+- Added `.github/dependabot.yml` for the `github-actions` ecosystem. Pinning
+  without automation means never receiving an action's own security fixes;
+  Dependabot bumps the SHA and rewrites the version comment. It does not read
+  `.forgejo/workflows`, so those pins need a manual bump.
+- `zizmor` now audits the workflows in CI via `make audit-workflows`, so the
+  pinning policy is enforced on every run rather than caught in review. Fixing
+  its other findings in the process:
+  - Replaced `${{ github.ref_name }}` interpolations in `release.yaml` with
+    `$GITHUB_REF_NAME`. Interpolated values are substituted into the script
+    before the shell sees them, so a ref containing shell metacharacters would
+    have executed.
+  - Added `persist-credentials: false` to all nine checkouts. None of them push
+    over git, so none needs a credential left in `.git/config`.
+  - Added explicit least-privilege `permissions:` to `test.yaml` and
+    `badge.yaml`; `security-scan` keeps its override for uploading SARIF.
+  - Documented why `badge.yaml`'s `workflow_run` trigger is safe, inline with
+    the suppression, rather than leaving the audit permanently failing.
 
 ## [0.2.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ the template formats bumps the minor version until `1.0.0`.
   separate lineage; `v5` and `v6` exist only upstream, while `v7` exists in both.
   Pinning `v5` would have meant leaving Forgejo on `node20` indefinitely with a
   permanent, unexplainable version skew between the two files.
+- Bumped the remaining Node 20 actions so no workflow is annotated for a
+  deprecated runtime: `github/codeql-action/upload-sarif` `@v3` → `@v4`,
+  `azure/setup-kubectl` `@v3` → `@v5`, and `helm/kind-action` `@v1.8.0` → `@v1`.
+  CodeQL Action v3 additionally carried its own deprecation, scheduled for
+  December 2026. `setup-kubectl@v4` is still `node20`, so `v5` is the first major
+  that resolves it.
+- `helm/kind-action` now tracks the `v1` major rather than an exact patch,
+  matching every other action pin in the file. The exact pin is how it drifted
+  six minor versions behind.
 
 ## [0.2.0] - 2026-08-11
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 # kubectl.fish Makefile
 # Provides convenient commands for development, testing, and installation
 
-.PHONY: help install uninstall install-templates diff-templates test test-unit test-integration lint format lint-fix check-formatting clean check-deps check-fish version-check version-check-tag release-notes
+.PHONY: help install uninstall install-templates diff-templates test test-unit test-integration lint format lint-fix check-formatting clean check-deps check-fish version-check version-check-tag release-notes audit-workflows
+
+# Pinned so a zizmor release cannot change CI's verdict without a commit here.
+# Dependabot does not manage this, so bump it by hand.
+ZIZMOR_VERSION ?= 1.29.0
 
 # Default target
 help: ## Show this help message
@@ -265,6 +269,19 @@ release-check: lint test version-check ## Run all checks before release
 # Note: failures below use { ...; exit 1; } rather than ( ...; exit 1 ). A
 # subshell's exit only ends the subshell, so with more commands on the same
 # recipe line the check would report the error and then carry on to succeed.
+audit-workflows: ## Audit GitHub workflows with zizmor (needs uv or pipx)
+	@if command -v uvx >/dev/null 2>&1; then \
+		runner="uvx"; \
+	elif command -v pipx >/dev/null 2>&1; then \
+		runner="pipx run"; \
+	else \
+		echo "❌ zizmor needs either uv or pipx installed"; \
+		echo "   brew install uv   # or: brew install pipx"; \
+		exit 1; \
+	fi; \
+	echo "Auditing .github/workflows with zizmor $(ZIZMOR_VERSION)..."; \
+	$$runner zizmor==$(ZIZMOR_VERSION) .github/workflows/
+
 version-check: ## Verify VERSION is semver and matches the newest CHANGELOG entry
 	@test -f VERSION || { echo "❌ VERSION file is missing"; exit 1; }
 	@test -f CHANGELOG.md || { echo "❌ CHANGELOG.md is missing"; exit 1; }


### PR DESCRIPTION
The checkout bump in `2f5c19d` cleared its own annotation, but I verified on that merged commit that three actions still target Node 20 and are being forced onto Node 24:

| Action | Was | Now | Why |
|--------|-----|-----|-----|
| `github/codeql-action/upload-sarif` | `@v3` | `@v4` | Node 20, **plus** its own deprecation dated December 2026 |
| `azure/setup-kubectl` | `@v3` | `@v5` | Node 20 — see below, v4 is not enough |
| `helm/kind-action` | `@v1.8.0` | `@v1` | Node 20 |

**`setup-kubectl` goes to v5, not v4.** `@v4` is still `using: node20`, so bumping to it would have moved the pin without fixing the annotation. v5 is the first major on `node24`. I checked each target's `action.yml` rather than assuming the next major was enough.

**`kind-action` now tracks the `v1` major** rather than an exact patch, matching every other pin in the file. The exact pin is precisely how it drifted six minor versions behind — latest is v1.14.0. If you'd rather keep exact pins for reproducibility, say so and I'll pin v1.14.0 instead; the file is currently inconsistent either way.

Inputs are unchanged across all three — `version`, `cluster_name`/`wait`, and `sarif_file` are stable in the target majors, so this is a pin bump with no call-site changes.

### Not in this PR

`aquasecurity/trivy-action` is pinned to `@master` — a mutable branch, not a release. It raises no annotation, so it's outside the stated scope of "clear the Node 20 warnings," but it's the least reproducible pin in the file: the scanner can change under you between runs with no diff. Latest tagged is v0.36.0. Happy to fix in a follow-up.

### No release

Recorded under `## [Unreleased]`; `VERSION` stays `0.2.0`. `make version-check` still passes and `make release-notes` still extracts 0.2.0's section.

### Verification note

The security-scan job is what exercises the trivy and codeql steps, so this PR's own run validates both. `badge.yaml` is untouched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated testing, Kubernetes tooling, and security scanning workflows to use current supported action versions.
  - Improved the reliability and maintainability of continuous integration checks.

- **Documentation**
  - Updated the unreleased changelog to record the workflow and security tooling updates, including the move to a major-version pin for Kubernetes environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->