### PR TITLE
fix(templates): derive pods-nodepools column widths from the data

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -101,6 +101,31 @@ kubectl's template engine is Go's `text/template` plus two extra functions,
 Guard every field access that may be absent with `exists`, and prefer `printf`
 for column alignment so the output needs no `column -t`.
 
+#### Column Widths
+
+A hardcoded width (`printf "%-46s ..."`) misaligns every row whose value
+overflows it, and generated names — Spark executors, Argo workflow steps — blow
+past any width you would want to reserve. Measure the data instead: `len`, `gt`
+and `printf` are all available, so a first `range` can find the widest value per
+column and build the format string once for both the header and the rows.
+
+```
+{{- $w := 3 -}}
+{{- range $i := .items }}{{ if gt (len $i.metadata.name) $w }}{{ $w = len $i.metadata.name }}{{ end }}{{ end -}}
+{{- $fmt := printf "%%-%ds %%s" $w -}}
+{{- printf $fmt "NAME" "STATUS" }}
+```
+
+Note the doubled `%%` — the outer `printf` emits the format string the inner one
+consumes.
+
+Keep that pass O(items). Measuring a column that only a nested-`range` join can
+resolve means running the join twice, and the join is the expensive part:
+`pods-nodepools.tmpl` takes ~4s on a 2200-pod namespace. That template therefore
+measures NODEPOOL from every `Node` in the `List`, which pads a little wider than
+the joined rows need, and seeds the width from its longest sentinel
+(`<node-gone>`) so values only reachable through the join still fit.
+
 ## Creating Your Own Templates
 
 1. Create a new `.tmpl` or `.template` file in one of the template directories
@@ -129,8 +154,9 @@ contain that sequence.
 - **Arrays**: Use `[*]` for all elements or `[0]` for first element
 - **Nested paths**: Chain with dots (e.g., `.status.conditions[*].type`)
 - **Test with kubectl**: Verify with `kubectl get ... -o json` first
-- **Go templates**: Guard optional fields with `exists`, align with `printf`, and
-  see `pods-nodepools.tmpl` for a worked cross-resource example
+- **Go templates**: Guard optional fields with `exists`, align with `printf` over
+  measured widths (see [Column Widths](#column-widths)), and see
+  `pods-nodepools.tmpl` for a worked cross-resource example
 
 ### Example: Creating a Custom Node Template
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -109,7 +109,7 @@ past any width you would want to reserve. Measure the data instead: `len`, `gt`
 and `printf` are all available, so a first `range` can find the widest value per
 column and build the format string once for both the header and the rows.
 
-```
+```gotemplate
 {{- $w := 3 -}}
 {{- range $i := .items }}{{ if gt (len $i.metadata.name) $w }}{{ $w = len $i.metadata.name }}{{ end }}{{ end -}}
 {{- $fmt := printf "%%-%ds %%s" $w -}}

--- a/templates/pods-nodepools.tmpl
+++ b/templates/pods-nodepools.tmpl
@@ -14,8 +14,32 @@ NODEPOOL prefers karpenter.sh/nodepool and falls back to
 kops.k8s.io/instance-group. Karpenter nodes carry both, and the nodepool is not
 always derivable from the instance-group name, so the real label must win. */ -}}
 {{- $all := .items -}}
-{{- printf "%-46s %-10s %-21s %-33s %s" "POD" "STATUS" "NODE" "NODEPOOL" "INSTANCE-TYPE" }}
+{{- /* Measure the columns before printing any of them. Generated pod names run
+from ~20 to ~80 characters, so a hardcoded width misaligns every row that
+overflows it. This pass is O(items) - negligible beside the nested join below -
+because it only measures fields it can read off a single item: NODE comes from
+the pods, NODEPOOL from every Node in the List rather than just the ones that
+turn out to host a pod, which can pad NODEPOOL a little wider than the joined
+rows strictly need. $wNp starts at len "<node-gone>" so that sentinel, which is
+only reachable through the join, never overflows either. */ -}}
+{{- $wPod := 3 }}{{ $wStatus := 6 }}{{ $wNode := 4 }}{{ $wNp := 11 -}}
+{{- range $i := $all -}}
+{{- if eq $i.kind "Pod" -}}
+{{- if gt (len $i.metadata.name) $wPod }}{{ $wPod = len $i.metadata.name }}{{ end -}}
+{{- $s := "-" }}{{ if exists $i.status "phase" }}{{ $s = $i.status.phase }}{{ end -}}
+{{- if gt (len $s) $wStatus }}{{ $wStatus = len $s }}{{ end -}}
+{{- $n := "<unscheduled>" }}{{ if exists $i.spec "nodeName" }}{{ $n = $i.spec.nodeName }}{{ end -}}
+{{- if gt (len $n) $wNode }}{{ $wNode = len $n }}{{ end -}}
+{{- else if eq $i.kind "Node" -}}
+{{- $l := "" -}}
+{{- if exists $i.metadata.labels "karpenter.sh/nodepool" }}{{ $l = index $i.metadata.labels "karpenter.sh/nodepool" }}{{ else if exists $i.metadata.labels "kops.k8s.io/instance-group" }}{{ $l = index $i.metadata.labels "kops.k8s.io/instance-group" }}{{ end -}}
+{{- if gt (len $l) $wNp }}{{ $wNp = len $l }}{{ end -}}
+{{- end -}}
+{{- end -}}
+{{- $fmt := printf "%%-%ds %%-%ds %%-%ds %%-%ds %%s" $wPod $wStatus $wNode $wNp -}}
+{{- printf $fmt "POD" "STATUS" "NODE" "NODEPOOL" "INSTANCE-TYPE" }}
 {{ range $p := $all }}{{ if eq $p.kind "Pod" -}}
+{{- $status := "-" }}{{ if exists $p.status "phase" }}{{ $status = $p.status.phase }}{{ end -}}
 {{- $node := "<unscheduled>" }}{{ if exists $p.spec "nodeName" }}{{ $node = $p.spec.nodeName }}{{ end -}}
 {{- $found := false }}{{ $np := "-" }}{{ $type := "-" -}}
 {{- range $n := $all }}{{ if and (eq $n.kind "Node") (eq $n.metadata.name $node) -}}
@@ -24,5 +48,5 @@ always derivable from the instance-group name, so the real label must win. */ -}
 {{- if exists $n.metadata.labels "node.kubernetes.io/instance-type" }}{{ $type = index $n.metadata.labels "node.kubernetes.io/instance-type" }}{{ end -}}
 {{- end }}{{ end -}}
 {{- if and (not $found) (ne $node "<unscheduled>") }}{{ $np = "<node-gone>" }}{{ end -}}
-{{- printf "%-46s %-10s %-21s %-33s %s" $p.metadata.name $p.status.phase $node $np $type }}
+{{- printf $fmt $p.metadata.name $status $node $np $type }}
 {{ end }}{{ end -}}


### PR DESCRIPTION
## Problem

`pods-nodepools.tmpl` padded its columns with hardcoded widths (`printf "%-46s %-10s %-21s %-33s %s"`). Any pod name longer than 46 characters shoved every following column right, and generated names — Spark executors, dbt model runs — reach ~80 characters, so most rows in a busy namespace were misaligned:

```
data--dbt--main-03331kdh                       Running    i-0f77aa28c918349f8   arm64-on-demand    m6gd.8xlarge
dbt-main-fact-hightouch-employer-linkedin-conversions-0b8dfa9ff15daaae-exec-1 Running    i-00b6f93e8c6808af9   spark-spot         r7gd.12xlarge
```

## Fix

Measure POD, STATUS, NODE and NODEPOOL in a pass over `.items`, then build the format string once with `printf` and share it between the header and the rows. Only `len`, `gt` and `printf` are needed, all of which kubectl's template engine has — no arithmetic, no Sprig.

```
POD                                                             STATUS    NODE                NODEPOOL                  INSTANCE-TYPE
data--dbt--main-0gtsucxt                                        Pending   i-012305d6f598fb850 arm64-on-demand           r6gd.12xlarge
```

### Why the measuring pass is O(items)

Measuring a column that only the nested-`range` join can resolve would mean running that join twice, and the join is the expensive part: ~4s on a 2200-pod namespace, measured. So the pass reads POD/STATUS/NODE straight off each `Pod` and NODEPOOL off each `Node`. Two consequences, both documented in the template:

- NODEPOOL is measured from every `Node` in the `List`, not just the ones hosting a pod, so it can pad a little wider than the joined rows strictly need.
- Its width is seeded from `len "<node-gone>"` so that sentinel — reachable only through the join — still fits.

STATUS now falls back to `-` when `.status.phase` is absent, which keeps `len` from erroring on a nil and stops `<no value>` from overflowing the column.

## Verification

- Rendered against a fixture covering a 76-char pod name, an unscheduled pod, a `<node-gone>` pod and a kops `instance-group` node, using a local stand-in for kubectl's go-template printer (same funcMap: `exists`, `base64decode`).
- Rendered against a live cluster via `kubectl -o go-template-file` (kubectl 1.25) and end to end through `k get pods,nodes ^pods-nodepools`.
- `make lint` clean; `make test-unit` 133 passed, 0 failed.

## Docs

`templates/README.md` gains a **Column Widths** subsection under Go Templates: the failure mode, a worked example (including the doubled `%%` that trips people up), and the O(items) constraint with the tradeoff it implies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Pod and node pool table formatting with dynamically sized columns for better readability.
  * Added safer Pod status display handling.
* **Documentation**
  * Added guidance and examples for measuring and aligning dynamic column widths in Go templates.
  * Documented the cross-resource formatting exception for Pod and node pool output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->